### PR TITLE
bugfix

### DIFF
--- a/assets/commands/index.js
+++ b/assets/commands/index.js
@@ -148,7 +148,7 @@ module.exports = class Commands {
 
     static _checkShapefilesExist(filePath) {
         const exts = ['.shp', '.shx', '.dbf'];
-        const missingFiles = exts.map(ext => filePath.replace(/\.shp/i, ext)).map(f => {
+        const missingFiles = exts.map(ext => filePath.replace(/\.shp$/i, ext)).map(f => {
             return fs.existsSync(f) ? { success: true } : { success: false, file: path.basename(f) };
         }).filter(r => !r.success).map(r => r.file);
 


### PR DESCRIPTION
Fixed #41 
Now it's ok to use path with ".shp" in the middle.
I think it helpful because the compressed shapefiles online ( e.g. GEOFABRIK) are named "xxxxxx.shp.zip" and leave the ".shp" in the folder name after decompression ( and I'm lazy to change 😂) .